### PR TITLE
Implement the selector plugins

### DIFF
--- a/plugins/AB-InputSelector/OneKnobPlugin.cpp
+++ b/plugins/AB-InputSelector/OneKnobPlugin.cpp
@@ -72,6 +72,18 @@ protected:
             parameter.ranges.def = kParameterDefaults[kParameterSelect];
             parameter.ranges.min = -100.0f;
             parameter.ranges.max = 100.0f;
+            {
+                ParameterEnumerationValue *values = new ParameterEnumerationValue[3];
+                parameter.enumValues.values = values;
+                parameter.enumValues.count = 3;
+                parameter.enumValues.restrictedMode = false;
+                values[0].value = -100.0f;
+                values[0].label = "A";
+                values[1].value = 0.0f;
+                values[1].label = "A/B";
+                values[2].value = 100.0f;
+                values[2].label = "B";
+            }
             break;
         case kParameterMode:
             parameter.hints      = kParameterIsAutomable | kParameterIsInteger | kParameterIsBoolean;

--- a/plugins/AB-InputSelector/OneKnobPlugin.cpp
+++ b/plugins/AB-InputSelector/OneKnobPlugin.cpp
@@ -33,7 +33,7 @@ public:
     {
         init();
         sampleRateChanged(getSampleRate());
-        fABSmooth.setTimeConstant(1e-3f);
+        abSmooth.setTimeConstant(1e-3f);
     }
 
 protected:
@@ -122,14 +122,13 @@ protected:
     {
         OneKnobPlugin::sampleRateChanged(newSampleRate);
 
-        fABSmooth.setSampleRate((float)newSampleRate);
+        abSmooth.setSampleRate((float)newSampleRate);
     }
 
     void activate() override
     {
         OneKnobPlugin::activate();
 
-        LinearSmoother &abSmooth = fABSmooth;
         abSmooth.setTarget((parameters[kParameterSelect] + 100.0f) / 200.0f);
         abSmooth.clearToTarget();
     }
@@ -143,11 +142,10 @@ protected:
         float *lo = outputs[0];
         float *ro = outputs[1];
 
-        LinearSmoother &abSmooth = fABSmooth;
         abSmooth.setTarget((parameters[kParameterSelect] + 100.0f) / 200.0f);
 
         for (uint32_t i = 0; i < frames; ++i) {
-            float sel = fABSmooth.next();
+            float sel = abSmooth.next();
             float As = std::sqrt(1.0f - sel);
             float Bs = std::sqrt(sel);
             lo[i] = As * l1[i]+Bs * l2[i];
@@ -156,7 +154,7 @@ protected:
     }
 
     // -------------------------------------------------------------------
-    LinearSmoother fABSmooth;
+    LinearSmoother abSmooth;
 
     DISTRHO_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OneKnobInputSelectorPlugin)
 };

--- a/plugins/AB-OutputSelector/OneKnobPlugin.cpp
+++ b/plugins/AB-OutputSelector/OneKnobPlugin.cpp
@@ -33,7 +33,7 @@ public:
     {
         init();
         sampleRateChanged(getSampleRate());
-        fABSmooth.setTimeConstant(1e-3f);
+        abSmooth.setTimeConstant(1e-3f);
     }
 
 protected:
@@ -122,14 +122,13 @@ protected:
     {
         OneKnobPlugin::sampleRateChanged(newSampleRate);
 
-        fABSmooth.setSampleRate((float)newSampleRate);
+        abSmooth.setSampleRate((float)newSampleRate);
     }
 
     void activate() override
     {
         OneKnobPlugin::activate();
 
-        LinearSmoother &abSmooth = fABSmooth;
         abSmooth.setTarget((parameters[kParameterSelect] + 100.0f) / 200.0f);
         abSmooth.clearToTarget();
     }
@@ -143,11 +142,10 @@ protected:
         float *l2 = outputs[2];
         float *r2 = outputs[3];
 
-        LinearSmoother &abSmooth = fABSmooth;
         abSmooth.setTarget((parameters[kParameterSelect] + 100.0f) / 200.0f);
 
         for (uint32_t i = 0; i < frames; ++i) {
-            float sel = fABSmooth.next();
+            float sel = abSmooth.next();
             float As = std::sqrt(1.0f - sel);
             float Bs = std::sqrt(sel);
             l1[i] = As*li[i];
@@ -158,7 +156,7 @@ protected:
     }
 
     // -------------------------------------------------------------------
-    LinearSmoother fABSmooth;
+    LinearSmoother abSmooth;
 
     DISTRHO_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OneKnobOutputSelectorPlugin)
 };

--- a/plugins/AB-OutputSelector/OneKnobPlugin.cpp
+++ b/plugins/AB-OutputSelector/OneKnobPlugin.cpp
@@ -72,6 +72,18 @@ protected:
             parameter.ranges.def = kParameterDefaults[kParameterSelect];
             parameter.ranges.min = -100.0f;
             parameter.ranges.max = 100.0f;
+            {
+                ParameterEnumerationValue *values = new ParameterEnumerationValue[3];
+                parameter.enumValues.values = values;
+                parameter.enumValues.count = 3;
+                parameter.enumValues.restrictedMode = false;
+                values[0].value = -100.0f;
+                values[0].label = "A";
+                values[1].value = 0.0f;
+                values[1].label = "A/B";
+                values[2].value = 100.0f;
+                values[2].label = "B";
+            }
             break;
         case kParameterMode:
             parameter.hints      = kParameterIsAutomable | kParameterIsInteger | kParameterIsBoolean;

--- a/plugins/common/ExpSmoother.hpp
+++ b/plugins/common/ExpSmoother.hpp
@@ -36,8 +36,8 @@ class ExpSmoother {
 public:
     void setSampleRate(float newSampleRate) noexcept
     {
-        if (fSampleRate != newSampleRate) {
-            fSampleRate = newSampleRate;
+        if (sampleRate != newSampleRate) {
+            sampleRate = newSampleRate;
             updateCoef();
         }
     }
@@ -45,55 +45,54 @@ public:
     void setTimeConstant(float newT60) noexcept
     {
         float newTau = newT60 * (float)(1.0 / 6.91);
-        if (fTau != newTau) {
-            fTau = newTau;
+        if (tau != newTau) {
+            tau = newTau;
             updateCoef();
         }
     }
 
     float getCurrentValue() const noexcept
     {
-        return fMem;
+        return mem;
     }
 
     float getTarget() const noexcept
     {
-        return fTarget;
+        return target;
     }
 
-    void setTarget(float target) noexcept
+    void setTarget(float newTarget) noexcept
     {
-        fTarget = target;
+        target = newTarget;
     }
 
     void clear() noexcept
     {
-        fMem = 0.0f;
+        mem = 0.0f;
     }
 
     void clearToTarget() noexcept
     {
-        fMem = fTarget;
+        mem = target;
     }
 
     float next() noexcept
     {
-        float coef = fCoef;
-        return (fMem = fMem * coef + fTarget * (1.0f - coef));
+        return (mem = mem * coef + target * (1.0f - coef));
     }
 
 private:
     void updateCoef() noexcept
     {
-        fCoef = std::exp(-1.0f / (fTau * fSampleRate));
+        coef = std::exp(-1.0f / (tau * sampleRate));
     }
 
 private:
-    float fCoef = 0.0f;
-    float fTarget = 0.0f;
-    float fMem = 0.0f;
-    float fTau = 0.0f;
-    float fSampleRate = 0.0f;
+    float coef = 0.0f;
+    float target = 0.0f;
+    float mem = 0.0f;
+    float tau = 0.0f;
+    float sampleRate = 0.0f;
 };
 
 #endif // DISTRHO_EXP_SMOOTHER_HPP_INCLUDED

--- a/plugins/common/ExpSmoother.hpp
+++ b/plugins/common/ExpSmoother.hpp
@@ -14,6 +14,9 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#ifndef DISTRHO_EXP_SMOOTHER_HPP_INCLUDED
+#define DISTRHO_EXP_SMOOTHER_HPP_INCLUDED
+
 #include <cmath>
 
 /**
@@ -92,3 +95,5 @@ private:
     float fTau = 0.0f;
     float fSampleRate = 0.0f;
 };
+
+#endif // DISTRHO_EXP_SMOOTHER_HPP_INCLUDED

--- a/plugins/common/ExpSmoother.hpp
+++ b/plugins/common/ExpSmoother.hpp
@@ -1,0 +1,81 @@
+/*
+ * DISTRHO OneKnob Series
+ * Copyright (C) 2021 Jean Pierre Cimalando <jp-dev@inbox.ru>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any purpose with
+ * or without fee is hereby granted, provided that the above copyright notice and this
+ * permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD
+ * TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN
+ * NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+ * DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER
+ * IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <cmath>
+
+class ExpSmoother {
+public:
+    void setSampleRate(float newSampleRate) noexcept
+    {
+        if (fSampleRate != newSampleRate) {
+            fSampleRate = newSampleRate;
+            updateCoef();
+        }
+    }
+
+    void setTimeConstant(float newT60) noexcept
+    {
+        float newTau = newT60 * (float)(1.0 / 6.91);
+        if (fTau != newTau) {
+            fTau = newTau;
+            updateCoef();
+        }
+    }
+
+    float getCurrentValue() const noexcept
+    {
+        return fMem;
+    }
+
+    float getTarget() const noexcept
+    {
+        return fTarget;
+    }
+
+    void setTarget(float target) noexcept
+    {
+        fTarget = target;
+    }
+
+    void clear() noexcept
+    {
+        fMem = 0.0f;
+    }
+
+    void clearToTarget() noexcept
+    {
+        fMem = fTarget;
+    }
+
+    float next() noexcept
+    {
+        float coef = fCoef;
+        return (fMem = fMem * coef + fTarget * (1.0f - coef));
+    }
+
+private:
+    void updateCoef() noexcept
+    {
+        fCoef = std::exp(-1.0f / (fTau * fSampleRate));
+    }
+
+private:
+    float fCoef = 0.0f;
+    float fTarget = 0.0f;
+    float fMem = 0.0f;
+    float fTau = 1e-3f;
+    float fSampleRate = 44100.0f;
+};

--- a/plugins/common/ExpSmoother.hpp
+++ b/plugins/common/ExpSmoother.hpp
@@ -27,7 +27,7 @@
  * exponential curve.
  *
  * The length of the curve is defined by a T60 constant, which
- * is the take it takes for a 1-to-0 smoothing to fall to -60dB.
+ * is the time it takes for a 1-to-0 smoothing to fall to -60dB.
  *
  * Note that this smoother has asymptotical behavior, and it must
  * not be assumed that the final target is ever reached.

--- a/plugins/common/ExpSmoother.hpp
+++ b/plugins/common/ExpSmoother.hpp
@@ -16,6 +16,19 @@
 
 #include <cmath>
 
+/**
+ * @brief An exponential smoother for control values
+ *
+ * This continually smooths a value towards a defined target,
+ * using a low-pass filter of the 1st order, which creates an
+ * exponential curve.
+ *
+ * The length of the curve is defined by a T60 constant, which
+ * is the take it takes for a 1-to-0 smoothing to fall to -60dB.
+ *
+ * Note that this smoother has asymptotical behavior, and it must
+ * not be assumed that the final target is ever reached.
+ */
 class ExpSmoother {
 public:
     void setSampleRate(float newSampleRate) noexcept
@@ -76,6 +89,6 @@ private:
     float fCoef = 0.0f;
     float fTarget = 0.0f;
     float fMem = 0.0f;
-    float fTau = 1e-3f;
-    float fSampleRate = 44100.0f;
+    float fTau = 0.0f;
+    float fSampleRate = 0.0f;
 };

--- a/plugins/common/LinearSmoother.hpp
+++ b/plugins/common/LinearSmoother.hpp
@@ -36,67 +36,67 @@ class LinearSmoother {
 public:
     void setSampleRate(float newSampleRate) noexcept
     {
-        if (fSampleRate != newSampleRate) {
-            fSampleRate = newSampleRate;
+        if (sampleRate != newSampleRate) {
+            sampleRate = newSampleRate;
             updateStep();
         }
     }
 
     void setTimeConstant(float newTau) noexcept
     {
-        if (fTau != newTau) {
-            fTau = newTau;
+        if (tau != newTau) {
+            tau = newTau;
             updateStep();
         }
     }
 
     float getCurrentValue() const noexcept
     {
-        return fMem;
+        return mem;
     }
 
     float getTarget() const noexcept
     {
-        return fTarget;
+        return target;
     }
 
-    void setTarget(float target) noexcept
+    void setTarget(float newTarget) noexcept
     {
-        if (fTarget != target) {
-            fTarget = target;
+        if (target != newTarget) {
+            target = newTarget;
             updateStep();
         }
     }
 
     void clear() noexcept
     {
-        fMem = 0.0f;
+        mem = 0.0f;
     }
 
     void clearToTarget() noexcept
     {
-        fMem = fTarget;
+        mem = target;
     }
 
     float next() noexcept
     {
-        float y0 = fMem;
-        float dy = fTarget - y0;
-        return (fMem = y0 + std::copysign(std::fmin(std::abs(dy), std::abs(fStep)), dy));
+        float y0 = mem;
+        float dy = target - y0;
+        return (mem = y0 + std::copysign(std::fmin(std::abs(dy), std::abs(step)), dy));
     }
 
 private:
     void updateStep() noexcept
     {
-        fStep = (fTarget - fMem) / (fTau * fSampleRate);
+        step = (target - mem) / (tau * sampleRate);
     }
 
 private:
-    float fStep = 0.0f;
-    float fTarget = 0.0f;
-    float fMem = 0.0f;
-    float fTau = 0.0f;
-    float fSampleRate = 0.0f;
+    float step = 0.0f;
+    float target = 0.0f;
+    float mem = 0.0f;
+    float tau = 0.0f;
+    float sampleRate = 0.0f;
 };
 
 #endif // DISTRHO_LINEAR_SMOOTHER_HPP_INCLUDED

--- a/plugins/common/LinearSmoother.hpp
+++ b/plugins/common/LinearSmoother.hpp
@@ -20,7 +20,7 @@
 #include <cmath>
 
 /**
- * @brief An exponential smoother for control values
+ * @brief A linear smoother for control values
  *
  * This continually smooths a value towards a defined target,
  * using linear segments.

--- a/plugins/common/LinearSmoother.hpp
+++ b/plugins/common/LinearSmoother.hpp
@@ -14,6 +14,9 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#ifndef DISTRHO_LINEAR_SMOOTHER_HPP_INCLUDED
+#define DISTRHO_LINEAR_SMOOTHER_HPP_INCLUDED
+
 #include <cmath>
 
 /**
@@ -95,3 +98,5 @@ private:
     float fTau = 0.0f;
     float fSampleRate = 0.0f;
 };
+
+#endif // DISTRHO_LINEAR_SMOOTHER_HPP_INCLUDED

--- a/plugins/common/LinearSmoother.hpp
+++ b/plugins/common/LinearSmoother.hpp
@@ -16,6 +16,19 @@
 
 #include <cmath>
 
+/**
+ * @brief An exponential smoother for control values
+ *
+ * This continually smooths a value towards a defined target,
+ * using linear segments.
+ *
+ * The duration of the smoothing segment is defined by the given
+ * time constant. Every time the target changes, a new segment
+ * restarts for the whole duration of the time constant.
+ *
+ * Note that this smoother, unlike an exponential smoother,
+ * eventually should converge to its target value.
+ */
 class LinearSmoother {
 public:
     void setSampleRate(float newSampleRate) noexcept

--- a/plugins/common/LinearSmoother.hpp
+++ b/plugins/common/LinearSmoother.hpp
@@ -1,0 +1,84 @@
+/*
+ * DISTRHO OneKnob Series
+ * Copyright (C) 2021 Jean Pierre Cimalando <jp-dev@inbox.ru>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any purpose with
+ * or without fee is hereby granted, provided that the above copyright notice and this
+ * permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD
+ * TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN
+ * NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+ * DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER
+ * IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <cmath>
+
+class LinearSmoother {
+public:
+    void setSampleRate(float newSampleRate) noexcept
+    {
+        if (fSampleRate != newSampleRate) {
+            fSampleRate = newSampleRate;
+            updateStep();
+        }
+    }
+
+    void setTimeConstant(float newTau) noexcept
+    {
+        if (fTau != newTau) {
+            fTau = newTau;
+            updateStep();
+        }
+    }
+
+    float getCurrentValue() const noexcept
+    {
+        return fMem;
+    }
+
+    float getTarget() const noexcept
+    {
+        return fTarget;
+    }
+
+    void setTarget(float target) noexcept
+    {
+        if (fTarget != target) {
+            fTarget = target;
+            updateStep();
+        }
+    }
+
+    void clear() noexcept
+    {
+        fMem = 0.0f;
+    }
+
+    void clearToTarget() noexcept
+    {
+        fMem = fTarget;
+    }
+
+    float next() noexcept
+    {
+        float y0 = fMem;
+        float dy = fTarget - y0;
+        return (fMem = y0 + std::copysign(std::fmin(std::abs(dy), std::abs(fStep)), dy));
+    }
+
+private:
+    void updateStep() noexcept
+    {
+        fStep = (fTarget - fMem) / (fTau * fSampleRate);
+    }
+
+private:
+    float fStep = 0.0f;
+    float fTarget = 0.0f;
+    float fMem = 0.0f;
+    float fTau = 0.0f;
+    float fSampleRate = 0.0f;
+};


### PR DESCRIPTION
This implements the 2 plugins.
- changed the parameter smoother to linear
  the idea was that this will permit exact 0 and 1 gain values at either extreme, and so avoids any residuals from the other signal
- should `sampleRateChanged(getSampleRate())` be moved to OneKnobPlugin's `init()` perhaps?
- should we fill in scalePoint labels for the 2 value extremes? (also the -100 to 100 value range is questionable but I kept it)
